### PR TITLE
Abort imidiatelly and redirect.

### DIFF
--- a/gae-python/home.py
+++ b/gae-python/home.py
@@ -74,7 +74,7 @@ class HomePage(webapp.RequestHandler):
       # which will force a login to make sure this user has permission
       # to initialize the shared server credentials.
       if not user:
-        self.redirect("/reset")
+        self.redirect("/reset", abort=True)
 
       # Read and parse client secrets JSON file.
       secrets = parse_json_file(SECRETS_FILE)


### PR DESCRIPTION
When using self.redirect with webapp2 abort parameter is needed
in order to stop execution of the script.

This fixes issue #2
